### PR TITLE
Rename `find_by_id(id: id)` to `find_by(id: id)`

### DIFF
--- a/app/controllers/concerns/model_controller_behavior.rb
+++ b/app/controllers/concerns/model_controller_behavior.rb
@@ -56,7 +56,7 @@ module ModelControllerBehavior
     end
 
     def find_book(id)
-      QueryService.find_by_id(id: id)
+      QueryService.find_by(id: id)
     end
 
     def persister

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -30,6 +30,6 @@ class SolrDocument
   end
 
   def resource
-    @resource ||= QueryService.find_by_id(id: id)
+    @resource ||= QueryService.find_by(id: id)
   end
 end

--- a/app/persistence/valkyrie/persistence/fedora/query_service.rb
+++ b/app/persistence/valkyrie/persistence/fedora/query_service.rb
@@ -6,7 +6,7 @@ module Valkyrie::Persistence::Fedora
         Valkyrie::Persistence::Fedora::Queries::FindAllQuery.new.run
       end
 
-      def find_by_id(id:)
+      def find_by(id:)
         Valkyrie::Persistence::Fedora::Queries::FindByIdQuery.new(id).run
       end
 

--- a/app/persistence/valkyrie/persistence/memory/query_service.rb
+++ b/app/persistence/valkyrie/persistence/memory/query_service.rb
@@ -7,7 +7,7 @@ module Valkyrie::Persistence::Memory
       @adapter = adapter
     end
 
-    def find_by_id(id:)
+    def find_by(id:)
       cache[id] || raise(::Persister::ObjectNotFoundError)
     end
 
@@ -17,7 +17,7 @@ module Valkyrie::Persistence::Memory
 
     def find_members(model:)
       model.member_ids.map do |id|
-        find_by_id(id: id)
+        find_by(id: id)
       end
     end
   end

--- a/app/persistence/valkyrie/persistence/postgres/query_service.rb
+++ b/app/persistence/valkyrie/persistence/postgres/query_service.rb
@@ -6,7 +6,7 @@ module Valkyrie::Persistence::Postgres
         Valkyrie::Persistence::Postgres::Queries::FindAllQuery.new.run
       end
 
-      def find_by_id(id:)
+      def find_by(id:)
         Valkyrie::Persistence::Postgres::Queries::FindByIdQuery.new(id).run
       end
 

--- a/app/persistence/valkyrie/persistence/solr/query_service.rb
+++ b/app/persistence/valkyrie/persistence/solr/query_service.rb
@@ -7,7 +7,7 @@ module Valkyrie::Persistence::Solr
       @resource_factory = resource_factory
     end
 
-    def find_by_id(id:)
+    def find_by(id:)
       Valkyrie::Persistence::Solr::Queries::FindByIdQuery.new(id, connection: connection, resource_factory: resource_factory).run
     end
   end

--- a/app/persisters/appending_persister.rb
+++ b/app/persisters/appending_persister.rb
@@ -16,7 +16,7 @@ class AppendingPersister
 
     def append_model(model, parent_id)
       return unless parent_id
-      parent = query_service.find_by_id(id: parent_id)
+      parent = query_service.find_by(id: parent_id)
       parent.member_ids = parent.member_ids + [model.id]
       persister.save(model: parent)
     end

--- a/app/processors/valkyrie/processors/append_processor.rb
+++ b/app/processors/valkyrie/processors/append_processor.rb
@@ -11,7 +11,7 @@ module Valkyrie::Processors
 
     def run(model:)
       return unless append_id.present?
-      parent = query_service.find_by_id(id: append_id)
+      parent = query_service.find_by(id: append_id)
       parent.member_ids = parent.member_ids + [model.id]
       persister.save(model: parent)
     end

--- a/app/services/query_service.rb
+++ b/app/services/query_service.rb
@@ -3,7 +3,7 @@ class QueryService
   class_attribute :adapter
   self.adapter = Valkyrie.config.adapter
   class << self
-    delegate :find_all, :find_by_id, :find_members, to: :default_adapter
+    delegate :find_all, :find_by, :find_members, to: :default_adapter
 
     def default_adapter
       new(adapter: adapter)
@@ -11,7 +11,7 @@ class QueryService
   end
 
   attr_reader :adapter
-  delegate :find_all, :find_by_id, :find_members, to: :adapter_query_service
+  delegate :find_all, :find_by, :find_members, to: :adapter_query_service
   def initialize(adapter:)
     @adapter = adapter
   end

--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -24,7 +24,7 @@ RSpec.shared_examples 'a Valkyrie::Persister' do
   it "can handle language-typed RDF properties" do
     book = persister.save(model: resource_class.new(title: ["Test1", RDF::Literal.new("Test", language: :fr)]))
 
-    reloaded = query_service.find_by_id(id: book.id)
+    reloaded = query_service.find_by(id: book.id)
 
     expect(reloaded.title).to contain_exactly "Test1", RDF::Literal.new("Test", language: :fr)
   end
@@ -35,7 +35,7 @@ RSpec.shared_examples 'a Valkyrie::Persister' do
     book3 = persister.save(model: resource_class.new)
     parent = persister.save(model: resource_class.new(member_ids: [book2.id, book.id, book3.id]))
 
-    reloaded = query_service.find_by_id(id: parent.id)
+    reloaded = query_service.find_by(id: parent.id)
     expect(reloaded.member_ids).to eq [book2.id, book.id, book3.id]
   end
 
@@ -55,7 +55,7 @@ RSpec.shared_examples 'a Valkyrie::Persister' do
   it "can find that resource again" do
     id = persister.save(model: resource).id
 
-    expect(persister.adapter.query_service.find_by_id(id: id)).to be_kind_of resource_class
+    expect(persister.adapter.query_service.find_by(id: id)).to be_kind_of resource_class
   end
 
   it "can delete objects" do
@@ -63,7 +63,7 @@ RSpec.shared_examples 'a Valkyrie::Persister' do
     query_service = persister.adapter.query_service
     persister.delete(model: persisted)
 
-    expect { query_service.find_by_id(id: persisted.id) }.to raise_error ::Persister::ObjectNotFoundError
+    expect { query_service.find_by(id: persisted.id) }.to raise_error ::Persister::ObjectNotFoundError
   end
 
   context "when wrapped with a form object" do
@@ -84,7 +84,7 @@ RSpec.shared_examples 'a Valkyrie::Persister' do
       form = ResourceForm.new(CustomResource.new)
 
       persisted = persister.save(model: form)
-      reloaded = query_service.find_by_id(id: persisted.id)
+      reloaded = query_service.find_by(id: persisted.id)
 
       expect(reloaded).to be_kind_of(CustomResource)
     end

--- a/lib/valkyrie/specs/shared_specs/queries.rb
+++ b/lib/valkyrie/specs/shared_specs/queries.rb
@@ -18,14 +18,14 @@ RSpec.shared_examples 'a Valkyrie query provider' do
     end
   end
 
-  describe ".find_by_id" do
+  describe ".find_by" do
     it "returns a resource by id" do
       resource = persister.save(model: resource_class.new)
 
-      expect(query_service.find_by_id(id: resource.id).id).to eq resource.id
+      expect(query_service.find_by(id: resource.id).id).to eq resource.id
     end
     it "returns a ::Persister::ObjectNotFoundError for a non-found ID" do
-      expect { query_service.find_by_id(id: "123123123") }.to raise_error ::Persister::ObjectNotFoundError
+      expect { query_service.find_by(id: "123123123") }.to raise_error ::Persister::ObjectNotFoundError
     end
   end
 

--- a/script/benchmarker.rb
+++ b/script/benchmarker.rb
@@ -18,7 +18,7 @@ Valkyrie::Adapter.adapters.to_a[0..-2].each do |adapter_name, adapter|
       parent = adapter.persister.save(model: parent)
     end
     bench.report("#{adapter_name} reload parent with #{num_children} children") do
-      parent = adapter.query_service.find_by_id(id: parent.id)
+      parent = adapter.query_service.find_by(id: parent.id)
     end
     last_page = Page.new
     adapter.persister.save(model: last_page)

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Book do
       member = Persister.save(model: described_class.new)
       parent = described_class.new
       parent.member_ids = member.id
-      parent = QueryService.find_by_id(id: Persister.save(model: parent).id)
+      parent = QueryService.find_by(id: Persister.save(model: parent).id)
 
       expect(parent.member_ids).to eq [member.id]
     end

--- a/spec/persisters/appending_persister_spec.rb
+++ b/spec/persisters/appending_persister_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe AppendingPersister do
     form.append_id = parent.id
 
     output = persister.save(model: form)
-    reloaded = persister.adapter.query_service.find_by_id(id: parent.id)
+    reloaded = persister.adapter.query_service.find_by(id: parent.id)
 
     expect(reloaded.member_ids).to eq [output.id]
   end

--- a/spec/requests/books_spec.rb
+++ b/spec/requests/books_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Book Management" do
       delete "/books/#{book.id}"
 
       expect(response).to redirect_to root_path
-      expect { QueryService.find_by_id(id: book.id) }.to raise_error ::Persister::ObjectNotFoundError
+      expect { QueryService.find_by(id: book.id) }.to raise_error ::Persister::ObjectNotFoundError
     end
   end
 
@@ -83,6 +83,6 @@ RSpec.describe "Book Management" do
   end
 
   def find_book(id)
-    QueryService.find_by_id(id: id)
+    QueryService.find_by(id: id)
   end
 end


### PR DESCRIPTION
If you name the param, you don't need to name it in the method name
also.